### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/message-build.yml
+++ b/.github/workflows/message-build.yml
@@ -1,5 +1,10 @@
 name: Message Service Build
 
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/jsoehner/restful-booker-platform-trunk/security/code-scanning/7](https://github.com/jsoehner/restful-booker-platform-trunk/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define the least privileges required for the workflow. Based on the operations performed in the workflow, the following permissions are necessary:
- `contents: read` for accessing the repository contents.
- `packages: write` for pushing Docker images to Docker Hub.
- `id-token: write` for securely accessing secrets and tokens if needed.

This ensures that the workflow has only the permissions it needs to function correctly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
