### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/report-build.yml
+++ b/.github/workflows/report-build.yml
@@ -1,5 +1,9 @@
 name: Report Service Build
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/jsoehner/restful-booker-platform-trunk/security/code-scanning/6](https://github.com/jsoehner/restful-booker-platform-trunk/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function correctly. Based on the workflow's steps:
- `contents: read` is required for the `actions/checkout@v4` step to read the repository contents.
- `packages: write` is required for the Docker login and image push steps.
- No other permissions appear necessary.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
